### PR TITLE
Link the archive with DRP for best and seamless UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ dmypy.json
 assets/original/
 config.ini
 testing/
+linker/LinkWithKiwiOpen.xml
+linker/ninjakiwilocation.dat

--- a/RunHidden.vbs
+++ b/RunHidden.vbs
@@ -1,0 +1,2 @@
+Set objShell = WScript.CreateObject("WScript.Shell")
+objShell.Run "" & "python " & CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\presence.py bkgrnd", 0, True

--- a/RunHidden.vbs
+++ b/RunHidden.vbs
@@ -1,2 +1,8 @@
+Set filesys = CreateObject("Scripting.FileSystemObject")
 Set objShell = WScript.CreateObject("WScript.Shell")
-objShell.Run "" & "python " & CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\presence.py bkgrnd", 0, True
+If filesys.FileExists(CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\config.ini") Then
+    objShell.Run "" & "python " & CreateObject("Scripting.FileSystemObject").GetParentFolderName(WScript.ScriptFullName) & "\presence.py bkgrnd", 0, True
+Else
+    WScript.Echo "Please rename config.ini.example to config.ini or create your own config file to run"
+End If
+

--- a/linker/FindNinjaKiwi.bat
+++ b/linker/FindNinjaKiwi.bat
@@ -1,0 +1,52 @@
+@echo off
+
+set directory=%~dp0
+Pushd %directory%
+
+echo I need to find the location of the Ninja Kiwi Archive on your computer, and the easiest way to do that is for you to open it and see where it came from
+
+echo Checking admin rights...
+net session 1>nul 2>nul
+
+if not '%ERRORLEVEL%'=='0' (
+echo Admin rights not detected. Please run with admin perms
+pause
+EXIT /B
+)
+
+auditpol /set /category:{6997984C-797A-11D9-BED3-505054503030} /success:enable>nul
+
+taskkill /im "Ninja Kiwi Archive.exe" 1>nul 2>nul
+
+echo Please ensure Ninja Kiwi Archive is closed then reopen it. once you have reopened Ninja Kiwi Archive, come back here and press any key to continue
+pause>nul
+
+wevtutil qe Security /c:200 /f:text /rd:true /q:"*[System[(EventID=4688)]]">openedfiles.dat
+
+findstr /i "Ninja Kiwi Archive.exe" openedfiles.dat>ninjakiwilocation.dat
+
+set /p loc=<ninjakiwilocation.dat
+
+echo Ninja Kiwi Archive is at %loc:~19%
+
+set /a "result=%result%-19"
+
+call set parsed=%loc:~19%
+
+rem debug echo %parsed%
+
+set /p fgiddle=<LinkWithKiwipt5.dat
+
+>ninjakiwilocation.dat (
+echo|set /p="%parsed%%fgiddle%"
+)
+
+del openedfiles.dat 1>nul 2>nul
+
+if "%parsed%"=="~19" (
+echo TASK FAILED. please run me again and make sure that Ninja Kiwi Archive is closed when you start me.
+) else (
+echo task completed.
+)
+
+pause

--- a/linker/LinkWIthKiwipt1.xml
+++ b/linker/LinkWIthKiwipt1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!--
+This sample schedules a task to start notepad.exe at a specific time.
+-->
+<Task xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+    <RegistrationInfo>
+        <Date>2021-10-11T13:21:17-08:00</Date>
+        <Author>jojo2357</Author>
+        <Version>1.0.0</Version>
+        <Description>Runs DRP for Ninja Kiwi Archive in the background when the archive is opened</Description>
+    </RegistrationInfo>
+    <Triggers>
+        <EventTrigger>
+            <Enabled>true</Enabled>
+            <Subscription>
+                &lt;QueryList&gt;&lt;Query Id="0" Path="Security"&gt;&lt;Select Path="Security"&gt;*[System[Provider[@Name='Microsoft-Windows-Security-Auditing'] and Task = 13312 and (band(Keywords,9007199254740992)) and (EventID=4688)]] and *[EventData[(Data='

--- a/linker/LinkWithKiwi.bat
+++ b/linker/LinkWithKiwi.bat
@@ -1,0 +1,45 @@
+@echo off
+rem setlocal ENABLEDELAYEDEXPANSION
+
+set directory=%~dp0
+Pushd %directory%
+
+set "params=%*"
+cd /d "%~dp0" && ( if exist "%temp%\getadmin.vbs" del "%temp%\getadmin.vbs" ) && fsutil dirty query %systemdrive% 1>nul 2>nul || (  echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "cmd.exe", "/k cd ""%~sdp0"" && ""%~s0 %params%""", "", "runas", 1 >> "%temp%\getadmin.vbs" && "%temp%\getadmin.vbs" && exit /B )
+
+echo Checking admin rights...
+net session>nul
+
+cls
+
+if not '%ERRORLEVEL%'=='0' (
+echo Admin rights not detected. Please run with admin perms
+pause
+EXIT /B
+)
+
+if not exist ninjakiwilocation.dat call FindNinjaKiwi.bat
+
+rem if not exist %loc% set /a "loc=%%loc:~0,%result%%%"
+
+echo Setting security logger
+auditpol /set /category:{6997984C-797A-11D9-BED3-505054503030} /success:enable>nul
+
+(type LinkWithKiwipt1.xml && type ninjakiwilocation.dat && type LinkWithKiwipt4.xml)>LinkWithKiwiOpen.xml
+for %%a in ("%cd%") do set "p_dir=%%~dpa"
+echo %p_dir%
+echo %p_dir%\RunHidden.vbs>>LinkWithKiwiOpen.xml
+type LinkWithKiwipt2.xml>>LinkWithKiwiOpen.xml
+
+echo Creating tasks
+schtasks /create /tn NinjaKiwiRichPresenceOpen /XML LinkWithKiwiOpen.xml
+
+pause
+
+exit
+
+:fnf
+echo Could not locate Ninja Kiwi Archive.exe
+pause
+exit
+goto :eof

--- a/linker/LinkWithKiwipt2.xml
+++ b/linker/LinkWithKiwipt2.xml
@@ -1,0 +1,4 @@
+            </Command>
+        </Exec>
+    </Actions>
+</Task> 

--- a/linker/LinkWithKiwipt4.xml
+++ b/linker/LinkWithKiwipt4.xml
@@ -1,0 +1,17 @@
+            </Subscription>
+        </EventTrigger>
+    </Triggers>
+    <Principals>
+        <Principal id="Author">
+            <RunLevel>LeastPrivilege</RunLevel>
+        </Principal>
+    </Principals>
+    <Settings>
+        <Enabled>true</Enabled>
+        <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+        <AllowStartOnDemand>true</AllowStartOnDemand>
+        <AllowHardTerminate>true</AllowHardTerminate>
+    </Settings>
+    <Actions>
+        <Exec>
+            <Command>

--- a/linker/LinkWithKiwipt5.dat
+++ b/linker/LinkWithKiwipt5.dat
@@ -1,0 +1,1 @@
+')]]&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;

--- a/linker/UnlinkFromKiwi.bat
+++ b/linker/UnlinkFromKiwi.bat
@@ -1,0 +1,21 @@
+@echo off
+
+set "params=%*"
+cd /d "%~dp0" && ( if exist "%temp%\getadmin.vbs" del "%temp%\getadmin.vbs" ) && fsutil dirty query %systemdrive% 1>nul 2>nul || (  echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "cmd.exe", "/k cd ""%~sdp0"" && ""%~s0 %params%""", "", "runas", 1 >> "%temp%\getadmin.vbs" && "%temp%\getadmin.vbs" && exit /B )
+
+echo Checking admin rights...
+net session>nul
+
+cls
+
+if not '%ERRORLEVEL%'=='0' (
+echo Admin rights not detected. Please run with admin perms
+pause
+EXIT /B
+)
+
+schtasks /delete /tn NinjaKiwiRichPresenceOpen
+
+pause 
+
+exit

--- a/presence.py
+++ b/presence.py
@@ -1,7 +1,7 @@
 from pypresence import Presence
 import json, pprint, configparser, time, psutil, sys
 import pygetwindow as gw
-
+import os
 
 class rich_presence:
     def __init__(self):
@@ -34,6 +34,8 @@ class rich_presence:
             elif sys.platform.startswith("win32"):
                 print("Ninja Kiwi Archive is not running")
                 self.RPC.clear()
+                if close_on_close:
+                    exit()
             else:
                 pvars = self.presence_gen(self.format_gen)
                 # print("-------------------------\npresence_dict\n-------------------------")
@@ -88,5 +90,7 @@ class rich_presence:
                 self.presence_dict[field] = None
         return self.presence_dict
 
+os.chdir(sys.path[0])
+close_on_close = len(sys.argv) > 1 and sys.argv[1] == "bkgrnd"
 
 rich_presence()


### PR DESCRIPTION
TL;DR: uses windows task scheduler to make the DRP open and close when the archive does so the user does not have to turn on the drp every time and deal with an extra window.

First off, I love what you have here, so thank you for sharing! 

Secondly, I would like to add my own contribution that gives the end user more options and a better experience. To do this, I have recycled some files from my own rich presence for music (see the original and more in depth files [there](https://github.com/jojo2357/Music-Discord-Rich-Presence)). 

Features:
- [x] make a way to run this DRP completely hidden in the background ([RunHidden.vbs](https://github.com/jojo2357/ninja-kiwi-archive-rich-presence/blob/master/RunHidden.vbs))
- [x] make the DRP able to close when the archive closes ([in the script](https://github.com/jojo2357/ninja-kiwi-archive-rich-presence/blob/bfc5240b315b27686caf87c6d549e0aacd1903a2/presence.py#L37-L38))
- [x] make the DRP come back to life when the archive opens ([multiple files](https://github.com/jojo2357/ninja-kiwi-archive-rich-presence/tree/master/linker))
- [x] make this linkage undo-able if the user so chooses ([unlinker](https://github.com/jojo2357/ninja-kiwi-archive-rich-presence/blob/master/linker/UnlinkFromKiwi.bat))

These files work together to make the DRP pretend that it is actually a part of the archive; when the archive opens, the DRP is opened ***invisibly in the background***. When the archive closes, the DRP program dies, saving resources. However, if run by a user from command line, these features magically go away